### PR TITLE
add a new repo for a talk at the Paris Open Source Summit

### DIFF
--- a/paris/OWNERS
+++ b/paris/OWNERS
@@ -1,0 +1,3 @@
+approvers:
+    - ameukam
+    - guineveresaenger


### PR DESCRIPTION
I'm giving a talk at the [Paris Open Source Summit](https://www.opensourcesummit.paris/). I want to use this repo to demonstrate how to contribute to Kubernetes.