### PR TITLE
Improve Bay Area KubeDay README.

### DIFF
--- a/bay-area-kube-day/README.md
+++ b/bay-area-kube-day/README.md
@@ -1,6 +1,7 @@
 # Welcome to KubeDay!
 
-This is our practice folder for the Bay Area KubeCay 2019 workshop. 
-Here, you will learn how to interact with our bot commands and pull request workflow.
+This is our practice folder for the [Bay Area KubeDay 2019](https://www.eventbrite.com/e/kubeday-bay-area-2019-tickets-55937071286)
+workshop. Here, you will learn how to interact with our bot commands
+and pull request workflow.
 
 Welcome and have fun!


### PR DESCRIPTION
Fixed the spelling of "KubeDay" and added a link to the
event schedule.