### PR TITLE
Corrected the location in README from Seattle to Barcelona

### DIFF
--- a/barcelona/README.md
+++ b/barcelona/README.md
@@ -1,5 +1,5 @@
 # KubeCon Barcelona 2019: New Kubernetes Contributor Workshop
 
-This is the location of our Seattle New Contributor Workshop Pull Request activities.
+This is the location of our Barcelona New Contributor Workshop Pull Request activities.
 
 


### PR DESCRIPTION
The README file content was referring to the Seattle New Contributor
Workshop instead of Barcelona.