### PR TITLE
Add pluradj to Shanghai 2019 approvers

### DIFF
--- a/shanghai/2019/OWNERS
+++ b/shanghai/2019/OWNERS
@@ -23,6 +23,7 @@ approvers:
   - sureshanaparti
   - xiaoanyunfei
   - yanhan
+  - pluradj 
 
 reviewers:
   - yamahata


### PR DESCRIPTION
Signed-off-by: Jason Plurad <pluradj@gmail.com>