### PR TITLE
Add cndt-2019/OWNERS for training in JP

### DIFF
--- a/cndt-2019/OWNERS
+++ b/cndt-2019/OWNERS
@@ -1,0 +1,16 @@
+# See the OWNERS docs: https://go.k8s.io/community/contributors/guide/owners.md
+
+reviewers:
+  - atoato88
+  - k-toyoda-pi
+  - mkimuram
+  - oomichi
+  - shu-mutou
+  - s-ito-ts
+approvers:
+  - atoato88
+  - k-toyoda-pi
+  - mkimuram
+  - oomichi
+  - shu-mutou
+  - s-ito-ts


### PR DESCRIPTION
In a public event CloudNativeDays Tokyo, we have an upstream
training. This is for adding mentors.
Thank you, mentors.