### PR TITLE
Add README.md to cndt-2019

### DIFF
--- a/cndt-2019/README.md
+++ b/cndt-2019/README.md
@@ -1,0 +1,17 @@
+# CNDT 2019: Kubernetes Upstream Training
+
+<a href="https://github.com/kubernetes/kubernetes"><img src="https://github.com/kubernetes/kubernetes/raw/master/logo/logo.png" width="200"></a><a href="https://cloudnativedays.jp/cndt2019/"><img src="https://cloudnativedays.jp/cndt2019/assets/img/preview/about-sm-1.png" width="200"></a>
+
+Welcome to Kubernetes Upstream Training!!
+July 22th 2019 This is the location of our CNDT 2019 Kubernetes Upstream Training activities.
+
+## Docs
+
+Get started with [Kubernbetes documentation](https://github.com/kubernetes/community/tree/master/contributors/guide)
+
+## Attention
+
+We will take a group photo that includes all attendees and uplod it here at end of this training.
+If someone doesn't want to show your face in public, please let me know.
+
+


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

This PR adds README.md to folder of cndt-2019.
It's the start point for New Kubernetes Contributor Workshop.

**Does this PR introduce a user-facing change?**:
None

```release-note
None
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
None