### PR TITLE
Add ood-2019/OWNERS for training in JP

### DIFF
--- a/ood-2019/OWNERS
+++ b/ood-2019/OWNERS
@@ -1,0 +1,12 @@
+# See the OWNERS docs: https://go.k8s.io/community/contributors/guide/owners.md
+
+reviewers:
+  - atoato88
+  - k-toyoda-pi
+  - shu-mutou
+  - s-ito-ts
+approvers:
+  - atoato88
+  - k-toyoda-pi
+  - shu-mutou
+  - s-ito-ts


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

In a public event Okinawa Open Days 2019, we have an upstream
training. This is for adding mentors to `OWNERS` file.
Thank you, mentors.

**Which issue(s) this PR fixes**:

NONE

**Special notes for your reviewer**:

NONE

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

/assign @guineveresaenger 