### PR TITLE
Add work folder for training on Kubernetes Fest Tokyo 2020

### DIFF
--- a/kft-2020/OWNERS
+++ b/kft-2020/OWNERS
@@ -1,0 +1,12 @@
+# See the OWNERS docs: https://go.k8s.io/community/contributors/guide/owners.md
+
+reviewers:
+  - atoato88
+  - k-toyoda-pi
+  - shu-mutou
+  - s-ito-ts
+approvers:
+  - atoato88
+  - k-toyoda-pi
+  - shu-mutou
+  - s-ito-ts

--- a/kft-2020/README.md
+++ b/kft-2020/README.md
@@ -1,10 +1,12 @@
 # Kubernetes Fest Tokyo 2020: Kubernetes Upstream Training
 
-<a href="https://github.com/kubernetes/kubernetes"><img src="https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png" width="64"></a><a href="xxx"><img src="./images/xxx.png"></a>
+<!--
+![Kubernetes Fest Tokyo 2020](./images/xxx.png)
+-->
 
 Welcome to Kubernetes Upstream Training!!
 
-This is the location of our Kubernetes Fest Tokyo 2020 Kubernetes Upstream Training (June 13th 2020) activities.
+This is the location of our Kubernetes Fest Tokyo 2020: Kubernetes Upstream Training (June 13th 2020) activities.
 
 ## 資料 (Documents)
 
@@ -12,7 +14,8 @@ This is the location of our Kubernetes Fest Tokyo 2020 Kubernetes Upstream Train
 * [スライド Slides](docs/k8s-upstream-training-kft-2020.pdf)
 * [Kubernbetes contributors guide](https://github.com/kubernetes/community/tree/master/contributors/guide)
 
+<!--
 ## We got new contributors!! 
 
-To be done.
 ![group photo](images/xxx.jpg)
+-->

--- a/kft-2020/README.md
+++ b/kft-2020/README.md
@@ -1,0 +1,18 @@
+# Kubernetes Fest Tokyo 2020: Kubernetes Upstream Training
+
+<a href="https://github.com/kubernetes/kubernetes"><img src="https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png" width="64"></a><a href="xxx"><img src="./images/xxx.png"></a>
+
+Welcome to Kubernetes Upstream Training!!
+
+This is the location of our Kubernetes Fest Tokyo 2020 Kubernetes Upstream Training (June 13th 2020) activities.
+
+## 資料 (Documents)
+
+* [参加者の皆様への宿題 Attendee prerequisites (in preparation)](docs/attendee-prerequisites.md)
+* [スライド Slides](docs/k8s-upstream-training-kft-2020.pdf)
+* [Kubernbetes contributors guide](https://github.com/kubernetes/community/tree/master/contributors/guide)
+
+## We got new contributors!! 
+
+To be done.
+![group photo](images/xxx.jpg)

--- a/kft-2020/docs/attendee-prerequisites.md
+++ b/kft-2020/docs/attendee-prerequisites.md
@@ -1,0 +1,68 @@
+ワークショップに参加する前に
+============================
+
+# メールアドレスについて
+
+以下の CNCF CLA サインアップにおいて、
+**企業の開発者として登録する**場合は、メールアドレスは企業ドメインのアドレスを使用する必要があります。
+_企業として参画する予定だが、ワークショップまでに間に合わない場合は、個人開発者としてサインアップしておいてください。_
+具体的には、以下のメールアドレスです。
+
+* GitHub の **Primary email address**
+* Linux Foundation ID のメールアドレス
+
+Primary email address が一致していないと Pull Request を行った時に Kubernetes の CI テストで失敗し、
+`cncf-cla: no`のラベルが付いてしまい、マージできないため、登録するメールアドレスには注意が必要です。
+
+# GitHub アカウントの作成
+
+* GitHub アカウントを持っていない人は作成してください。
+* GitHub アカウントをすでに持っている場合は Settings -> Emails で、**Primary email address** が
+  Linux Foundation ID に登録するアドレスに設定してください。企業の開発者の場合はとくに注意。
+  
+なお、Github のコミットで別の email を使用したい場合は、
+そのメールアドレスを (Primary 以外の) **Emails** に登録しておけばよい。
+
+# CNCF CLA へのサインアップ
+* Linux Foundation ID の取得
+  + [LF sign up](https://identity.linuxfoundation.org/) へアクセス
+  + 持っていない場合は[ここ](https://identity.linuxfoundation.org/)から作成する。
+    - ユーザ名、メールアドレスなどを入力して登録ボタンを押下
+    - メールアドレス宛に確認メールが来るので、メール中のURLにブラウザからアクセスする。
+  + すでに持っている場合は、メールアドレスが要件を満たすものになっているかを確認、企業の開発者の場合は注意。
+* Linux Foundation ID と GitHub アカウントの紐付け
+  + Linux Foundationn ID の [Social network logins](https://identity.linuxfoundation.org/user/me/hybridauth) に
+    アクセスし github アカウントと紐付ける。
+
+* CNCF CLA sign up
+  1. 企業内で CNCF 開発参加者のリスト管理者に名前の追加を依頼する。
+  2. CNCFの[当該ページ](https://identity.linuxfoundation.org/projects/cncf)の "Sign up to contribute to this project as an employee" をクリック。(この手順で "Groups:Authorized CNCF Contributors" が設定される。)
+    * 個人開発者の場合は "Sign up to contribute to this project as an individual" をクリック
+  3. The Linux Foudation ID を使ってログインする。
+  4. [https://identity.linuxfoundation.org/user/me](https://identity.linuxfoundation.org/user/me) に下記が表示されることを確認する。
+    - Groups:Authorized CNCF Contributors
+    - CNCF-<企業名が判断できる名称> (← 企業の開発者として登録している場合のみ)
+    - **Note**: もし "CNCF-<企業名が判断できる名称>" が付いているが、"Groups:Authorized CNCF Contributors" が付いてない場合は、再度手順2から実施する。
+
+# Kubernetes の Slack を登録
+* ここから登録します。https://slack.k8s.io/
+* ログイン後に以下のチャンネルに入ってください。
+  + #jp-dev
+    このチャンネルの中で、事前の質疑応答、レビュー依頼の練習、フォローなど行っていきます。
+
+# コマンドのインストール
+* 以下のコマンドをインストールしておいてください。
+  + git
+  + golang
+  + docker
+
+# Git や GitHub の操作
+* 基本的な Git や GitHub の操作には慣れておいてください。
+* 以下も参考にしてください。
+  + https://github.com/kubernetes/community/blob/master/contributors/guide/contributor-cheatsheet/README-ja.md#%E8%B2%A2%E7%8C%AE%E3%81%99%E3%82%8B
+
+# リポジトリのフォークとクローン
+* 以下のリポジトリを自分の GitHub アカウントにフォークしておいてください。
+  + https://github.com/kubernetes-sigs/contributor-playground
+  + https://github.com/kubernetes/kubernetes
+* 次に自分のアカウントにフォークしたリポジトリを自分の PC にクローンしておいてください。

--- a/kft-2020/hands_on.md
+++ b/kft-2020/hands_on.md
@@ -1,0 +1,28 @@
+```shell
+$ git clone https://github.com/foo/contributor-playground
+$ cd contributor-playground
+$ git remote add upstream
+https://github.com/kubernetes-sigs/contributor-playground
+
+$ git remote -v
+origin  https://github.com/foo/contributor-playground (fetch)
+origin  https://github.com/foo/contributor-playground (push)
+upstream        https://github.com/kubernetes-sigs/contributor-playground (fetch)
+upstream        https://github.com/kubernetes-sigs/contributor-playground (push)
+
+$ cd kft-2020/workdir/
+$ git checkout -b add_foo_md
+$ vim foo.md
+$ git add foo.md
+$ git commit -m "Add foo.md"
+
+$ git fetch upstream
+$ git rebase upstream/master
+$ git push origin add_foo_md
+
+access https://github.com/kubernetes-sigs/contributor-playground
+
+create PR
+
+ask reviews on slack #jp-dev
+```


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

We will hold Kubernetes upstream training In a public event Kubernetes Fetst Tokyo 2020(formerly [Kubernetes Community Day Tokyo 2020](https://kubernetescommunitydays.org/events/2020-tokyo/)).
This PR adds work place folder for the event and some assets for training, and also OWNERS file.

**Which issue(s) this PR fixes**:

None

**Special notes for your reviewer**:

None

**Does this PR introduce a user-facing change?**:

```release-note
None
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
