### PR TITLE
Change event name to KubeFest Tokyo 2020

### DIFF
--- a/kft-2020/README.md
+++ b/kft-2020/README.md
@@ -1,12 +1,12 @@
-[![Kubernetes Fest Tokyo 2020](./images/kubernetes-tokyo-transparent.png)](https://k8sjp.connpass.com/event/176105/)
+[![KubeFest Tokyo 2020](./images/kubernetes-tokyo-transparent.png)](https://k8sjp.connpass.com/event/176105/)
 
 ---
 
-# Kubernetes Fest Tokyo 2020: Kubernetes Upstream Training
+# KubeFest Tokyo 2020: Kubernetes Upstream Training
 
 Welcome to Kubernetes Upstream Training!!
 
-This is the location of our [Kubernetes Fest Tokyo 2020](https://k8sjp.connpass.com/event/176105/): Kubernetes Upstream Training (June 13th 2020) activities.
+This is the location of our [KubeFest Tokyo 2020](https://k8sjp.connpass.com/event/176105/): Kubernetes Upstream Training (June 13th 2020) activities.
 
 ## 資料 (Documents)
 


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

This PR changes event name from "Kubernetes Fest Tokyo 2020" to "KubeFest Tokyo 2020", because that canonical name for it has been decided to "KubeFest Tokyo 2020".

**Which issue(s) this PR fixes**:

NONE

**Special notes for your reviewer**:

NONE

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

NONE
