### PR TITLE
Add checking company policy before joining workshop

### DIFF
--- a/kft-2020/docs/attendee-prerequisites.md
+++ b/kft-2020/docs/attendee-prerequisites.md
@@ -6,6 +6,10 @@
 まずは、CNCF コミュニティ行動規範をご一読ください
 https://github.com/cncf/foundation/blob/master/code-of-conduct-languages/jp.md
 
+# オープンソース参加規約の確認
+
+所属企業によっては、企業として参加、個人として参加に関わらずオープンソースに貢献するために規約を定めていることがあります。
+
 # メールアドレスについて
 
 以下の CNCF CLA サインアップにおいて、


### PR DESCRIPTION
/kind documentation

**What this PR does / why we need it**:

Developer should check the company policy before joining workshop to contribute.
This commit adds this.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
