### PR TITLE
Extract facilitators from slide to README on Japan

### DIFF
--- a/japan/cndo-2021/README.md
+++ b/japan/cndo-2021/README.md
@@ -18,11 +18,11 @@ This is the location of [CloudNative Days Spring 2021 Online](https://event.clou
 
 | Icon | Name | Affiliation | Focus on, Role.. |
 | ------------- | ------------- | ------------- | ------------- |
-|<a href="https://github.com/atoato88"><img src="https://avatars.githubusercontent.com/u/748740?s=50"></a>| Akihito Inoh | NEC Solution Innovators | - sig-cluster-lifecycle<br> - k/dashboard i18n ja |
-|<a href="https://github.com/shu-mutou"><img src="https://avatars.githubusercontent.com/u/12838129?s=50"></a>| Shu Muto | NEC Solution Innovators | - sig-ui<br> - Approver of k/dashboard |
-|| Yuiko Mouri | NEC Solution Innovators | - sig-node |
-|| Kohei Toyoda | NEC Solution Innovators | - sig-testing |
-|| Shingo Ito | NEC Solution Innovators | - sig-testing |
+|<a href="https://github.com/atoato88"><img src="https://avatars.githubusercontent.com/u/748740?s=50"></a>| <a href="https://github.com/atoato88">Akihito Inoh</a> | NEC Solution Innovators | - sig-cluster-lifecycle<br> - k/dashboard i18n ja |
+|<a href="https://github.com/shu-mutou"><img src="https://avatars.githubusercontent.com/u/12838129?s=50"></a>| <a href="https://github.com/shu-mutou">Shu Muto</a> | NEC Solution Innovators | - sig-ui<br> - Approver of k/dashboard |
+|<a href="https://github.com/YuikoTakada"><img src="https://avatars.githubusercontent.com/u/6335296?s=50"></a>| <a href="https://github.com/YuikoTakada">Yuiko Mouri</a> | NEC Solution Innovators | - sig-node |
+|<a href="https://github.com/k-toyoda-pi"><img src="https://avatars.githubusercontent.com/u/26761953?s=50"></a>| <a href="https://github.com/k-toyoda-pi">Kohei Toyoda</a> | NEC Solution Innovators | - sig-testing |
+|<a href="https://github.com/s-ito-ts"><img src="https://avatars.githubusercontent.com/u/42854771?s=50"></a>| <a href="https://github.com/s-ito-ts">Shingo Ito</a> | NEC Solution Innovators | - sig-testing |
 
 ## We got new contributors!! 
 

--- a/japan/cndo-2021/README.md
+++ b/japan/cndo-2021/README.md
@@ -14,6 +14,16 @@ This is the location of [CloudNative Days Spring 2021 Online](https://event.clou
 * [スライド Slides](../assets/slide.pdf)
 * [Kubernbetes contributors guide](https://github.com/kubernetes/community/tree/master/contributors/guide)
 
+## 講師（Facilitators）
+
+| Icon | Name | Affiliation | Focus on, Role.. |
+| ------------- | ------------- | ------------- | ------------- |
+|<a href="https://github.com/atoato88"><img src="https://avatars.githubusercontent.com/u/748740?s=50"></a>| Akihito Inoh | NEC Solution Innovators | - sig-cluster-lifecycle<br> - k/dashboard i18n ja |
+|<a href="https://github.com/shu-mutou"><img src="https://avatars.githubusercontent.com/u/12838129?s=50"></a>| Shu Muto | NEC Solution Innovators | - sig-ui<br> - Approver of k/dashboard |
+|| Yuiko Mouri | NEC Solution Innovators | - sig-node |
+|| Kohei Toyoda | NEC Solution Innovators | - sig-testing |
+|| Shingo Ito | NEC Solution Innovators | - sig-testing |
+
 ## We got new contributors!! 
 
 Photo of attendees will be shown here after this training!

--- a/japan/cndt-2019/README.md
+++ b/japan/cndt-2019/README.md
@@ -11,14 +11,16 @@ July 22th 2019 This is the location of our CNDT 2019 Kubernetes Upstream Trainin
 
 Get started with [Kubernbetes documentation](https://github.com/kubernetes/community/tree/master/contributors/guide)
 
-## Facilitators
+## Facilitators, Tutors
 
 | Icon | Name | Affiliation | Focus on, Role.. |
 | ------------- | ------------- | ------------- | ------------- |
-|<a href="https://github.com/atoato88"><img src="https://avatars.githubusercontent.com/u/748740?s=50"></a>| <a href="https://github.com/atoato88">Akihito Inoh</a> | NEC Solution Innovators | - sig-cluster-lifecycle<br> - k/dashboard i18n ja |
-|<a href="https://github.com/shu-mutou"><img src="https://avatars.githubusercontent.com/u/12838129?s=50"></a>| <a href="https://github.com/shu-mutou">Shu Muto</a> | NEC Solution Innovators | - sig-ui<br> - Approver of k/dashboard |
+|<a href="https://github.com/oomichi"><img src="https://avatars.githubusercontent.com/u/1287154?s=50"></a>| <a href="https://github.com/oomichi">Kenichi Omichi</a> | NEC | - sig-testing<br> - approver of /test in k/k |
+|| <a href="https://github.com/mkimuram">Masaki Kimura</a> | Hitachi | - sig-storage<br> - member of kubernetes |
+|<a href="https://github.com/shu-mutou"><img src="https://avatars.githubusercontent.com/u/12838129?s=50"></a>| <a href="https://github.com/shu-mutou">Shu Muto</a> | NEC Solution Innovators | - sig-ui |
 |<a href="https://github.com/k-toyoda-pi"><img src="https://avatars.githubusercontent.com/u/26761953?s=50"></a>| <a href="https://github.com/k-toyoda-pi">Kohei Toyoda</a> | NEC Solution Innovators | - sig-testing |
 |<a href="https://github.com/s-ito-ts"><img src="https://avatars.githubusercontent.com/u/42854771?s=50"></a>| <a href="https://github.com/s-ito-ts">Shingo Ito</a> | NEC Solution Innovators | - sig-testing |
+|<a href="https://github.com/atoato88"><img src="https://avatars.githubusercontent.com/u/748740?s=50"></a>| <a href="https://github.com/atoato88">Akihito Inoh</a> | NEC Solution Innovators | - sig-cluster-lifecycle<br> - sig-docs-ja |
 
 ## We got new contributors!! 
 

--- a/japan/cndt-2019/README.md
+++ b/japan/cndt-2019/README.md
@@ -11,6 +11,15 @@ July 22th 2019 This is the location of our CNDT 2019 Kubernetes Upstream Trainin
 
 Get started with [Kubernbetes documentation](https://github.com/kubernetes/community/tree/master/contributors/guide)
 
+## Facilitators
+
+| Icon | Name | Affiliation | Focus on, Role.. |
+| ------------- | ------------- | ------------- | ------------- |
+|<a href="https://github.com/atoato88"><img src="https://avatars.githubusercontent.com/u/748740?s=50"></a>| <a href="https://github.com/atoato88">Akihito Inoh</a> | NEC Solution Innovators | - sig-cluster-lifecycle<br> - k/dashboard i18n ja |
+|<a href="https://github.com/shu-mutou"><img src="https://avatars.githubusercontent.com/u/12838129?s=50"></a>| <a href="https://github.com/shu-mutou">Shu Muto</a> | NEC Solution Innovators | - sig-ui<br> - Approver of k/dashboard |
+|<a href="https://github.com/k-toyoda-pi"><img src="https://avatars.githubusercontent.com/u/26761953?s=50"></a>| <a href="https://github.com/k-toyoda-pi">Kohei Toyoda</a> | NEC Solution Innovators | - sig-testing |
+|<a href="https://github.com/s-ito-ts"><img src="https://avatars.githubusercontent.com/u/42854771?s=50"></a>| <a href="https://github.com/s-ito-ts">Shingo Ito</a> | NEC Solution Innovators | - sig-testing |
+
 ## We got new contributors!! 
 
 ![group photo](group-photo.jpg)

--- a/japan/cndt-2020/README.md
+++ b/japan/cndt-2020/README.md
@@ -14,6 +14,15 @@ This is the location of [CloudNative Days Tokyo 2020](https://cndt2020.cloudnati
 * [スライド Slides](../assets/slide.pdf)
 * [Kubernbetes contributors guide](https://github.com/kubernetes/community/tree/master/contributors/guide)
 
+## 講師（Facilitators）
+
+| Icon | Name | Affiliation | Focus on, Role.. |
+| ------------- | ------------- | ------------- | ------------- |
+|<a href="https://github.com/atoato88"><img src="https://avatars.githubusercontent.com/u/748740?s=50"></a>| <a href="https://github.com/atoato88">Akihito Inoh</a> | NEC Solution Innovators | - sig-cluster-lifecycle<br> - k/dashboard i18n ja |
+|<a href="https://github.com/shu-mutou"><img src="https://avatars.githubusercontent.com/u/12838129?s=50"></a>| <a href="https://github.com/shu-mutou">Shu Muto</a> | NEC Solution Innovators | - sig-ui<br> - Approver of k/dashboard |
+|<a href="https://github.com/k-toyoda-pi"><img src="https://avatars.githubusercontent.com/u/26761953?s=50"></a>| <a href="https://github.com/k-toyoda-pi">Kohei Toyoda</a> | NEC Solution Innovators | - sig-testing |
+|<a href="https://github.com/s-ito-ts"><img src="https://avatars.githubusercontent.com/u/42854771?s=50"></a>| <a href="https://github.com/s-ito-ts">Shingo Ito</a> | NEC Solution Innovators | - sig-testing |
+
 ## We got new contributors!! 
 
 ![group photo 01](images/cndt-2020-01.png) ![group photo 02](images/cndt-2020-02.png)

--- a/japan/kft-2020/README.md
+++ b/japan/kft-2020/README.md
@@ -14,6 +14,15 @@ This is the location of our [KubeFest Tokyo 2020](https://k8sjp.connpass.com/eve
 * [スライド Slides](../assets/slide.pdf)
 * [Kubernbetes contributors guide](https://github.com/kubernetes/community/tree/master/contributors/guide)
 
+## 講師（Facilitators）
+
+| Icon | Name | Affiliation | Focus on, Role.. |
+| ------------- | ------------- | ------------- | ------------- |
+|<a href="https://github.com/atoato88"><img src="https://avatars.githubusercontent.com/u/748740?s=50"></a>| <a href="https://github.com/atoato88">Akihito Inoh</a> | NEC Solution Innovators | - sig-cluster-lifecycle<br> - k/dashboard i18n ja |
+|<a href="https://github.com/shu-mutou"><img src="https://avatars.githubusercontent.com/u/12838129?s=50"></a>| <a href="https://github.com/shu-mutou">Shu Muto</a> | NEC Solution Innovators | - sig-ui<br> - Approver of k/dashboard |
+|<a href="https://github.com/k-toyoda-pi"><img src="https://avatars.githubusercontent.com/u/26761953?s=50"></a>| <a href="https://github.com/k-toyoda-pi">Kohei Toyoda</a> | NEC Solution Innovators | - sig-testing |
+|<a href="https://github.com/s-ito-ts"><img src="https://avatars.githubusercontent.com/u/42854771?s=50"></a>| <a href="https://github.com/s-ito-ts">Shingo Ito</a> | NEC Solution Innovators | - sig-testing |
+
 ## We got new contributors!! 
 
 ![group photo 01](images/kft2020-01.png) ![group photo 02](images/kft2020-02.png)

--- a/japan/ood-2019/README.md
+++ b/japan/ood-2019/README.md
@@ -12,6 +12,15 @@ This is the location of our OOD 2019 Kubernetes Upstream Training (Dec 9th 2019)
 * [スライド Slides](../assets/slide.pdf)
 * [Kubernbetes contributors guide](https://github.com/kubernetes/community/tree/master/contributors/guide)
 
+## 講師（Facilitators）
+
+| Icon | Name | Affiliation | Focus on, Role.. |
+| ------------- | ------------- | ------------- | ------------- |
+|<a href="https://github.com/atoato88"><img src="https://avatars.githubusercontent.com/u/748740?s=50"></a>| <a href="https://github.com/atoato88">Akihito Inoh</a> | NEC Solution Innovators | - sig-cluster-lifecycle<br> - k/dashboard i18n ja |
+|<a href="https://github.com/shu-mutou"><img src="https://avatars.githubusercontent.com/u/12838129?s=50"></a>| <a href="https://github.com/shu-mutou">Shu Muto</a> | NEC Solution Innovators | - sig-ui<br> - Approver of k/dashboard |
+|<a href="https://github.com/k-toyoda-pi"><img src="https://avatars.githubusercontent.com/u/26761953?s=50"></a>| <a href="https://github.com/k-toyoda-pi">Kohei Toyoda</a> | NEC Solution Innovators | - sig-testing |
+|<a href="https://github.com/s-ito-ts"><img src="https://avatars.githubusercontent.com/u/42854771?s=50"></a>| <a href="https://github.com/s-ito-ts">Shingo Ito</a> | NEC Solution Innovators | - sig-testing |
+
 ## We got new contributors!! 
 
 ![group photo](images/ood2019-photo.jpg


### PR DESCRIPTION
This PR extracts facilitators list from slide file to `README.md` on each Japan event.
As of now, facilitators list is included in workshop slide file.

It's good to extract informations which depends on each event to `README.md`, because that workshop slide for Japan event was moved to `japan/assets` folder as common asset.
