### PR TITLE
Add slack name to README in cndo-2021

### DIFF
--- a/japan/cndo-2021/README.md
+++ b/japan/cndo-2021/README.md
@@ -14,15 +14,30 @@ This is the location of [CloudNative Days Spring 2021 Online](https://event.clou
 * [スライド Slides](../assets/slide.pdf)
 * [Kubernbetes contributors guide](https://github.com/kubernetes/community/tree/master/contributors/guide)
 
+## スケジュール (Timetable)
+
+| Time | Contents | 
+| ------------- | ------------- | 
+| 13:00-14:00(60m) | Kubernetes コミュニティ | 
+| (10m) | Break | 
+| 14:10-14:50(40m) | Kubernetes 開発環境 | 
+| (15m) | Break | 
+| 15:05-15:45(40m) | コントリビューション実践 | 
+| (10m) | Break | 
+| 15:55-17:15(1h20m) | ハンズオン | 
+| 17:15-17:30(15m) | クロージング | 
+
+Total:4h30m
+
 ## 講師（Facilitators）
 
-| Icon | Name | Affiliation | Focus on, Role.. |
-| ------------- | ------------- | ------------- | ------------- |
-|<a href="https://github.com/atoato88"><img src="https://avatars.githubusercontent.com/u/748740?s=50"></a>| <a href="https://github.com/atoato88">Akihito Inoh</a> | NEC Solution Innovators | - sig-cluster-lifecycle<br> - k/dashboard i18n ja |
-|<a href="https://github.com/shu-mutou"><img src="https://avatars.githubusercontent.com/u/12838129?s=50"></a>| <a href="https://github.com/shu-mutou">Shu Muto</a> | NEC Solution Innovators | - sig-ui<br> - Approver of k/dashboard |
-|<a href="https://github.com/YuikoTakada"><img src="https://avatars.githubusercontent.com/u/6335296?s=50"></a>| <a href="https://github.com/YuikoTakada">Yuiko Mouri</a> | NEC Solution Innovators | - sig-node |
-|<a href="https://github.com/k-toyoda-pi"><img src="https://avatars.githubusercontent.com/u/26761953?s=50"></a>| <a href="https://github.com/k-toyoda-pi">Kohei Toyoda</a> | NEC Solution Innovators | - sig-testing |
-|<a href="https://github.com/s-ito-ts"><img src="https://avatars.githubusercontent.com/u/42854771?s=50"></a>| <a href="https://github.com/s-ito-ts">Shingo Ito</a> | NEC Solution Innovators | - sig-testing |
+| Icon | Name | Slack | Affiliation | Focus on, Role.. |
+| ------------- | ------------- | ------------- | ------------- | ------------- |
+|<a href="https://github.com/atoato88"><img src="https://avatars.githubusercontent.com/u/748740?s=50"></a>| <a href="https://github.com/atoato88">Akihito Inoh</a> | @akihito-inou(atoato88) | NEC Solution Innovators | - sig-cluster-lifecycle<br> - k/dashboard i18n ja |
+|<a href="https://github.com/shu-mutou"><img src="https://avatars.githubusercontent.com/u/12838129?s=50"></a>| <a href="https://github.com/shu-mutou">Shu Muto</a> | @Shu Muto | NEC Solution Innovators | - sig-ui<br> - Approver of k/dashboard |
+|<a href="https://github.com/YuikoTakada"><img src="https://avatars.githubusercontent.com/u/6335296?s=50"></a>| <a href="https://github.com/YuikoTakada">Yuiko Mouri</a> | @YuikoTakada | NEC Solution Innovators | - sig-node |
+|<a href="https://github.com/k-toyoda-pi"><img src="https://avatars.githubusercontent.com/u/26761953?s=50"></a>| <a href="https://github.com/k-toyoda-pi">Kohei Toyoda</a> | @toyoda | NEC Solution Innovators | - sig-testing |
+|<a href="https://github.com/s-ito-ts"><img src="https://avatars.githubusercontent.com/u/42854771?s=50"></a>| <a href="https://github.com/s-ito-ts">Shingo Ito</a> | @s-ito | NEC Solution Innovators | - sig-testing |
 
 ## We got new contributors!! 
 


### PR DESCRIPTION
This PR adds items following to `README.md` in cndo-2021:
- Slack name for each facilitator
- Timetable for the event
