### PR TITLE
Add video index for adhoc training in japan folder

### DIFF
--- a/japan/adhoc/README.md
+++ b/japan/adhoc/README.md
@@ -12,4 +12,10 @@ PRのレビューは、[OWNERS](../OWNERS) ファイルに記載の者が対応�
 * [参加者の皆様への宿題 Attendee prerequisites (in preparation)](../assets/attendee-prerequisites.md)
 * [スライド Slides](../assets/slide.pdf)
 * [YouTube<br>![Kubernetes Upstream Training on YouTube](https://img.youtube.com/vi/79TiANhORMA/0.jpg)](https://www.youtube.com/watch?v=79TiANhORMA)
+  | Time | Contents | 
+  | ------------- | ------------- | 
+  | [00:00:00](https://www.youtube.com/watch?v=79TiANhORMA&t=0s) - (53m) | Kubernetes コミュニティ | 
+  | [00:53:10](https://www.youtube.com/watch?v=79TiANhORMA&t=3190s) - (31m) | Kubernetes 開発環境 | 
+  | [01:24:18](https://www.youtube.com/watch?v=79TiANhORMA&t=5058s) - (35m)| コントリビューション実践 | 
+  | [01:59:29](https://www.youtube.com/watch?v=79TiANhORMA&t=7169s) - (23m) | ハンズオン | 
 * [Kubernbetes contributors guide](https://github.com/kubernetes/community/tree/master/contributors/guide)


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:
This PR adds index for training video to `README` on `japan/adhoc`.
It will be more ease to watch the video.

**Which issue(s) this PR fixes**:
NONE

**Special notes for your reviewer**:
NONE

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
