### PR TITLE
Add oomichi to OWNERS on japan folder

### DIFF
--- a/japan/OWNERS
+++ b/japan/OWNERS
@@ -3,11 +3,13 @@
 reviewers:
   - atoato88
   - k-toyoda-pi
+  - oomichi
   - shu-mutou
   - s-ito-ts
 approvers:
   - atoato88
   - k-toyoda-pi
+  - oomichi
   - shu-mutou
   - s-ito-ts
   - YuikoTakada


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
/kind feature


**What this PR does / why we need it**:
This PR adds oomichi to OWNERS on `japan/` as reviewer and approver.
Recently he acts as collaborator on this repository.

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:
None

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
None
