### PR TITLE
brazil: add initial directory to hold the NCWs in Brazil

### DIFF
--- a/brazil/OWNERS
+++ b/brazil/OWNERS
@@ -1,0 +1,6 @@
+# See the OWNERS docs: https://go.k8s.io/community/contributors/guide/owners.md
+
+# contribex coordinators leading NCWs in Brazil
+approvers:
+  - cpanato
+  - rikatz

--- a/brazil/README.md
+++ b/brazil/README.md
@@ -1,0 +1,19 @@
+# Kubernetes Contributor Playground para o Brazil
+
+Olá novos contribuidores!
+
+Este repositório será utilizado como um espaço seguro para os participantes do Novo Onboarding de Contribuidores para se familarizar com alguns processos do projeto Kubernetes como revisão e pull request.
+
+Cada diretório dentro de `brazil/` contém material para o treinamentos `kubernetes upstream` conduzidos no Brasil.
+
+Por favor leia os documentos em cada sub diretório para os assuntos de comunidade, discussões, contribuiçoes, suporte e código de conduta.
+
+# Kubernetes Contributor Playground for Brazil
+
+Hello new contributors!
+
+This repository will be used as a safe space for participants in the New Contributor Onboarding Track to familiarize themselves with (some of) the Kubernetes Project's review and pull request processes.
+
+Each subfolder under `brazil/` contains assets for kubernetes upstream training held in events at Brazil.
+
+Please refer docs in each subfolder for community, discussion, contribution, support, and code of conduct.

--- a/brazil/attendee-instructions.md
+++ b/brazil/attendee-instructions.md
@@ -1,0 +1,75 @@
+# Attendee Instructions
+
+## Code of Conduct
+
+Please read the [Kubernetes Code of Conduct](https://github.com/kubernetes/community/blob/master/code-of-conduct.md) first.
+
+_We take the Code of Conduct very seriously so please ensure that you read this._
+
+## Sign CLA
+
+Before you can submit a contribution, you must [sign the Contributor License
+Agreement(CLA)](https://github.com/kubernetes/community/blob/master/CLA.md#how-do-i-sign).
+The Kubernetes project can _only_ accept a contribution if you or your company have signed the CLA.
+
+Should you encounter any problems signing the CLA, follow the [CLA
+troubleshooting guidelines](https://github.com/kubernetes/community/blob/master/CLA.md#troubleshooting).
+
+## Join the Kubernetes Slack
+
+- Sign up for the Kubernetes Slack [here](https://slack.k8s.io/).
+- India specific slack channels:
+    - **#in-dev** - for contributors
+    - **#in-users** - for users
+    - **#in-events** - for events
+- Say Hi and introduce yourself in the **#in-dev** channel! :smile:
+
+## Fork the repo
+
+- Fork this repository (https://github.com/kubernetes-sigs/contributor-playground) to your GitHub account.
+- Clone the forked repository locally. See the [GitHub workflow instructions](https://www.kubernetes.dev/docs/guide/github-workflow/) for more details.
+
+```shell
+$ git clone https://github.com/foo/contributor-playground
+$ cd contributor-playground
+$ git remote add upstream https://github.com/kubernetes-sigs/contributor-playground
+$ git remote set-url --push upstream no_push
+
+$ git remote -v
+origin  https://github.com/foo/contributor-playground (fetch)
+origin  https://github.com/foo/contributor-playground (push)
+upstream        https://github.com/kubernetes-sigs/contributor-playground (fetch)
+upstream        no_push (push)
+
+$ cd india/k8s-blr-2021/workdir
+$ git checkout -b add_foo_md
+$ vim foo.md
+$ git add foo.md
+$ git commit -m "Add foo.md"
+
+$ git fetch upstream
+$ git rebase upstream/master
+$ git push origin add_foo_md
+```
+
+## Create a PR
+
+Create a Pull Request on the https://github.com/kubernetes-sigs/contributor-playground repo.
+
+Try using different [bot commands](https://prow.k8s.io/command-help)!
+
+Here are some fun ones!
+
+```
+# for cats
+/meow
+
+# for dogs
+/woof
+
+# for ponies
+/pony
+
+# for a (bad) joke
+/joke
+```


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Together with @rikatz we are planning to do a New contributor workshop in Brazil in the upcoming months and this PR is the setup for the directory to hold the playground.

I think we need to translate to PT-BR the `brazil/attendee-instructions.md` but I can do it in a follow up

/assign @nikhita @rikatz


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
brazil: add initial directory to hold the NCWs in Brazil
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
