### PR TITLE
Add label area/japan

### DIFF
--- a/japan/OWNERS
+++ b/japan/OWNERS
@@ -17,3 +17,5 @@ approvers:
 emeritus_approvers:
   - k-toyoda-pi
   - s-ito-ts
+labels:
+  - area/japan


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

To search pull requests which are related to japan easily when contributor events happen in Japan, this adds the label `area/japan` for pull requests under japan/ directory.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
