### PR TITLE
docs: change link to https

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,21 +2,29 @@
 
 Hello new contributors!
 
-This repository will be used as a safe space for participants in the New Contributor Onboarding Track to familiarize themselves with (some of) the Kubernetes Project's review and pull request processes.
+This repository will be used as a safe space for participants in the New
+Contributor Onboarding Track to familiarize themselves with (some of) the
+Kubernetes Project's review and pull request processes.
 
-A [Youtube playlist](https://www.youtube.com/playlist?list=PL69nYSiGNLP3M5X7stuD7N4r3uP2PZQUx) of the New Contributor workshop has been posted, and an outline of content to videos can be found [here](http://git.k8s.io/community/events/2018/05-contributor-summit).
+A
+[Youtube playlist](https://www.youtube.com/playlist?list=PL69nYSiGNLP3M5X7stuD7N4r3uP2PZQUx)
+of the New Contributor workshop has been posted, and an outline of content to
+videos can be found
+[here](http://git.k8s.io/community/events/2018/05-contributor-summit).
 
 ## Community, discussion, contribution, and support
 
-Learn how to engage with the Kubernetes community on the [community page](http://kubernetes.io/community/).
+Learn how to engage with the Kubernetes community on the
+[community page](https://kubernetes.io/community/).
 
 You can reach the maintainers of this project at:
 
-- [Slack](http://slack.k8s.io/)
-- [Mailing List](https://groups.google.com/forum/#!forum/kubernetes-dev)
+-   [Slack](http://slack.k8s.io/)
+-   [Mailing List](https://groups.google.com/forum/#!forum/kubernetes-dev)
 
 ### Code of conduct
 
-Participation in the Kubernetes community is governed by the [Kubernetes Code of Conduct](code-of-conduct.md).
+Participation in the Kubernetes community is governed by the
+[Kubernetes Code of Conduct](code-of-conduct.md).
 
 [owners]: https://git.k8s.io/community/contributors/guide/owners.md


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:
Change link to kubernetes.io/community to `https`. This adds security to ensure unencrypted traffic is not intercepted.

**Special notes for your reviewer**:
Test PR to sign easyCLA.

**Does this PR introduce a user-facing change?**:
NONE

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
