### PR TITLE
Add coming upstream training schedule in Japan

### DIFF
--- a/japan/README.md
+++ b/japan/README.md
@@ -16,7 +16,12 @@ Please refer docs in each subfolder for community, discussion, contribution, sup
 
 コミュニティ、ディスカッション、コントリビューション、サポートそして行動規範(Code of conduct)については、各フォルダの資料を参照してください。
 
-## Kubernetes Upstream Trainings in Public Events
+## Coming Kubernetes Upstream Trainings
+
+- 2022/11/18: [Cloud Native Days Tokyo](https://event.cloudnativedays.jp/cndt2022/hands-on#hs0)
+- 2022/12/14: [Okinawa Open Days](https://www.okinawaopendays.com/2022-program)
+
+## Post Kubernetes Upstream Trainings
 
 <table>
   <tr>


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup
/kind documentation

**What this PR does / why we need it**:

To see future trainings easily, this adds the schedule.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
