### PR TITLE
Add `learners/` directory, to avoid conflict

### DIFF
--- a/remote/README.md
+++ b/remote/README.md
@@ -1,2 +1,5 @@
 ### Hello World!
 This is for all the aspiring kubernetes contributors who are learning online, watching youtube videos and reading blog posts
+
+**NOTE:**
+To avoid conflicting PRs, add the `<your github account>.md` file to the `learners/` directory instead of adding your github account to the `OWNERS` file.

--- a/remote/learners/shu-mutou.md
+++ b/remote/learners/shu-mutou.md
@@ -1,0 +1,1 @@
+Hello, k8s community!!


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

To avoid conflicting PRs, add the `<your github account>.md` file to the `learners/` directory instead of adding your github account to the `OWNERS` file.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
