### PR TITLE
Fix typo in README in `japan`

### DIFF
--- a/japan/README.md
+++ b/japan/README.md
@@ -16,7 +16,7 @@ Please refer docs in each subfolder for community, discussion, contribution, sup
 
 コミュニティ、ディスカッション、コントリビューション、サポートそして行動規範(Code of conduct)については、各フォルダの資料を参照してください。
 
-## Post Kubernetes Upstream Trainings
+## Past Kubernetes Upstream Trainings
 
 <table>
   <tr>


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind documentation

**What this PR does / why we need it**:
Fix typo

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs

```
