### PR TITLE
Remove odl description about EasyCLA in japan folder

### DIFF
--- a/japan/assets/attendee-prerequisites.md
+++ b/japan/assets/attendee-prerequisites.md
@@ -23,9 +23,8 @@
 * 企業の開発者として参加する人で、GitHub アカウントをすでに持っている場合は GitHub の Settings -> Emails で、**email address** の項目に企業で使う[メールアドレスを追加](https://docs.github.com/ja/account-and-profile/setting-up-and-managing-your-personal-account-on-github/managing-email-preferences/adding-an-email-address-to-your-github-account)してください。
 
 # CNCF CLA へのサインアップ
-Kubernetesコミュニティでは2022年3月頃にCLAの手順がEasyCLAに移行しており、以前とは手順が変更されています。
 
-ワークショップの事前作業としては、以下の[サインアップ事前作業](#サインアップ事前作業)を実施してください。  
+ワークショップの事前作業として、以下の[サインアップ事前作業](#サインアップ事前作業)を実施してください。  
 実際のサインアップはワークショップの中でPullRequestを作成した際に実施します。  
 
 *ワークショップに参加せずCNCF CLAへのサインアップだけ行いたい人は、[サインアップ事前作業](#サインアップ事前作業)と[サインアップ作業](#サインアップ作業)を実施してください。*


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
This PR removes a description which explains moving to EasyCLA.
EasyCLA is general process for signing the CLA at now, we can remove this description.

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:
None

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
None