### PR TITLE
add shu-mutou as root OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,13 +1,14 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-  - MadhavJivrajani
-  - Priyankasaggu11929
   - cblecker
   - jberkus
   - kaslin
+  - MadhavJivrajani
   - nikhita
   - palnabarun
+  - Priyankasaggu11929
+  - shu-mutou
 emeritus_approvers:
   - alisondy
   - guineveresaenger


### PR DESCRIPTION
Follow up AI from ContribEx Maintainers track (at KubeCon EU 2025)

Discussed offline with the current OWNERS.

cc: @kubernetes-sigs/sig-contributor-experience-leads 

