### PR TITLE
Create vishruth.md with personal details

### DIFF
--- a/remote/learners/vishruth.md
+++ b/remote/learners/vishruth.md
@@ -1,0 +1,9 @@
+## 👋 Hi, I’m Vishruth
+
+I’m a customer success engineer working deeply in the cloud-native and observability space. Most of my day is spent around Kubernetes, cloud platforms, CI/CD pipelines, and helping teams make complex systems more reliable and visible.
+
+I enjoy digging into how distributed systems actually behave in the real world, not just how diagrams say they should. I’m especially interested in Kubernetes internals, CNCF projects, OpenTelemetry, and making tooling simpler for developers and operators.
+
+I’m here to learn by contributing, improve documentation and tooling, and collaborate with people who enjoy breaking things (safely) to understand them better. I strongly believe small, consistent contributions compound over time.
+
+Outside work, I like exploring new tech, building side projects, and occasionally gaming to reset my brain.


### PR DESCRIPTION
This pull request adds a new learner profile for Vishruth, providing background information and interests relevant to cloud-native technologies and observability.

New learner profile:

* Added `vishruth.md` to the `remote/learners` directory, introducing Vishruth as a customer success engineer with interests in Kubernetes, CNCF projects, OpenTelemetry, and developer tooling. Added personal introduction and interests.
