### PR TITLE
Add jdfc-io to learners list

### DIFF
--- a/remote/learners/LEARNERS.md
+++ b/remote/learners/LEARNERS.md
@@ -10,3 +10,4 @@ learners:
 - blue86321
 - davidbaena
 - [ahmadidev](https://github.com/ahmadidev/)
+- [jdfc-io](https://github.com/jdfc-io)


### PR DESCRIPTION
What type of PR is this?

/kind documentation

What this PR does / why we need it:
Add jdfc-io to the remote/learners directory as a short learner introduction and for practicing the Kubernetes PR submission workflow.

Which issue(s) this PR fixes:

Fixes #

Special notes for your reviewer:
This is a small documentation-only change intended as a first contribution.

Does this PR introduce a user-facing change?:
NONE

Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
NONE