### PR TITLE
Add file to remote/learners/kaveh.md‎

### DIFF
--- a/remote/learners/kaveh.md
+++ b/remote/learners/kaveh.md
@@ -1,0 +1,1 @@
+First PR to sign the CLA!


### PR DESCRIPTION
## Summary
  This PR adds my learner profile to the contributor playground as my first contribution to satisfy Kubernetes community onboarding expectations.

  ## What Changed
  - Added `remote/learners/kaveh.md` with an introductory line:
    - `First PR to sign the CLA!`

  ## Why
  Kubernetes-related repos typically require:
  - A signed CLA before contributions can be merged
  - A valid first contribution that follows repo contribution flow

  This PR is intended as that initial onboarding contribution.

  ## Scope
  - Documentation-only change
  - No code, build, test, or runtime behavior changes

  ## Validation
  - Confirmed only one file is added on branch `sign-the-cla`
  - File path and format match existing learner-entry conventions
