### PR TITLE
Add vovtz to remote/learners folder

### DIFF
--- a/remote/learners/vovtz.asciidoc
+++ b/remote/learners/vovtz.asciidoc
@@ -1,0 +1,3 @@
+= Sign the K8s CLA by creation of a PR
+
+Add `vovtz` to remote learners, please.


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

Adds my learner file to `remote/learners/` as my first PR to sign the CNCF CLA and get familiar with the Kubernetes contribution workflow.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

First-time contributor practicing the PR flow.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs
NONE
```
