### PR TITLE
Add Chacoon3 to remote learners

### DIFF
--- a/remote/learners/Chacoon3.md
+++ b/remote/learners/Chacoon3.md
@@ -1,0 +1,1 @@
+Hello Kubernetes! This is my contributor playground entry.


### PR DESCRIPTION
Adds Chacoon3 to the remote learners directory to practice the Kubernetes contribution workflow and trigger the CNCF CLA check.